### PR TITLE
add theme variables to head

### DIFF
--- a/packages/modal-ui/src/utils/ThemeUtil.ts
+++ b/packages/modal-ui/src/utils/ThemeUtil.ts
@@ -91,18 +91,28 @@ export const ThemeUtil = {
   },
 
   setTheme() {
-    const root: HTMLElement | null = document.querySelector(':root')
+    const headTag = document.getElementsByTagName('head')[0]
+    const styleTag = document.createElement('style')
+
     const { themeVariables } = ThemeCtrl.state
 
-    if (root) {
-      const variables = {
-        ...themeModeVariables(),
-        ...themeVariablesPresets(),
-        ...themeVariables
-      }
-
-      Object.entries(variables).forEach(([key, val]) => root.style.setProperty(key, val))
+    const variables = {
+      ...themeModeVariables(),
+      ...themeVariablesPresets(),
+      ...themeVariables
     }
+
+    const styleValues = Object.entries(variables)
+      .map(([key, val]) => `${key}: ${val};`)
+      .join('\n')
+
+    styleTag.innerHTML = `
+    :root {
+      ${styleValues}
+    }
+    `
+
+    headTag.appendChild(styleTag)
   },
 
   globalCss: css`


### PR DESCRIPTION
Long story short, adding all these custom properties directly onto the `html` style attribute is kinda rude and creates a bad developer experience:

<img width="1003" alt="Screenshot 2024-03-14 at 10 24 39" src="https://github.com/WalletConnect/modal/assets/90316/ee459fe3-1be9-404e-bc61-5275c149632e">

This also applies to everyone using popular wallet libraries like Rainbowkit or Connectkit, as they all use this library.

### Solution

This PR proposes to add all theme-related custom properties into a `style` tag within the `head` under the `:root` pseudo class. Resulting in a clean DOM without any changes in functionality:

<img width="463" alt="Screenshot 2024-03-14 at 10 29 56" src="https://github.com/WalletConnect/modal/assets/90316/a968b576-59e0-4b71-a45a-ee5557b8fb31">

<img width="449" alt="Screenshot 2024-03-14 at 10 30 48" src="https://github.com/WalletConnect/modal/assets/90316/3b7743d1-e0ad-49ac-8f90-35606ee0c7ac">

### Possible Issues

Moving CSS declarations from `html` style property to `head` style tag decreases their specificity. Which in theory should not be an issue here as we only deal with custom properties with no actual CSS rules. But as there are no tests to check this out quickly, let me know if you can think of any more issues you could think of arising because of this reduced specificity.

And finally, here's a scientific representation of developer experience improvements after using this PR:

![8j7mth](https://github.com/WalletConnect/modal/assets/90316/e9637253-5227-4157-a0e2-04a4f3b2a18d)

