### PR TITLE
feat: add polyfill for copy in HTTP env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "18.2.7",
         "@typescript-eslint/eslint-plugin": "6.6.0",
         "@typescript-eslint/parser": "6.6.0",
+        "copy-to-clipboard": "^3.3.3",
         "esbuild": "0.17.9",
         "eslint": "8.49.0",
         "eslint-config-prettier": "9.0.0",
@@ -6173,6 +6174,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dev": true,
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/core-util-is": {
@@ -13564,6 +13574,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "dev": true
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "laboratory"
   ],
   "devDependencies": {
-    "@types/node": "20.6.0",
-    "@typescript-eslint/eslint-plugin": "6.6.0",
-    "@typescript-eslint/parser": "6.6.0",
-    "@rollup/plugin-replace": "5.0.2",
     "@rollup/plugin-commonjs": "25.0.4",
-    "@rollup/plugin-node-resolve": "15.2.1",
     "@rollup/plugin-json": "6.0.0",
-    "rollup-plugin-polyfill-node": "0.12.0",
+    "@rollup/plugin-node-resolve": "15.2.1",
+    "@rollup/plugin-replace": "5.0.2",
+    "@types/node": "20.6.0",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
+    "@typescript-eslint/eslint-plugin": "6.6.0",
+    "@typescript-eslint/parser": "6.6.0",
+    "copy-to-clipboard": "^3.3.3",
     "esbuild": "0.17.9",
     "eslint": "8.49.0",
     "eslint-config-prettier": "9.0.0",
@@ -46,8 +46,9 @@
     "prettier": "3.0.3",
     "rollup": "3.29.1",
     "rollup-plugin-esbuild": "5.0.0",
-    "rollup-plugin-minify-html-literals": "1.2.6",
     "rollup-plugin-lit-css": "4.0.1",
+    "rollup-plugin-minify-html-literals": "1.2.6",
+    "rollup-plugin-polyfill-node": "0.12.0",
     "typescript": "5.2.2"
   }
 }

--- a/packages/modal-ui/src/utils/UiUtil.ts
+++ b/packages/modal-ui/src/utils/UiUtil.ts
@@ -7,6 +7,7 @@ import {
   RouterCtrl,
   ToastCtrl
 } from '@walletconnect/modal-core'
+import copy from 'copy-to-clipboard'
 import type { LitElement } from 'lit'
 
 export const UiUtil = {
@@ -112,7 +113,11 @@ export const UiUtil = {
     const { walletConnectUri } = OptionsCtrl.state
     if (walletConnectUri) {
       try {
-        await navigator.clipboard.writeText(walletConnectUri)
+        if (navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(walletConnectUri)
+        } else {
+          copy(walletConnectUri)
+        }
         ToastCtrl.openToast('Link copied', 'success')
       } catch {
         ToastCtrl.openToast('Failed to copy', 'error')


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard only available in HTTPS, If use WalletConnect via HTTP, copy would failed.
 
# Changes

- feat: add polyfill for copy connect url.
